### PR TITLE
default.html: make homepage header not be a link

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -59,12 +59,16 @@
     class="{% if page.url == '/' %}homepage{% else %}inside-page{% endif %}"
   >
     <header>
+      {% if page.url != '/' %}
       <a href="/">
+      {% endif %}
         <div class="content">
           <h1>Open Path</h1>
           <h2>by Chad Whitacre</h2>
         </div>
+      {% if page.url != '/' %}
       </a>
+      {% endif %}
     </header>
     <article>{{ content }}</article>
     <footer>


### PR DESCRIPTION
On the homepage, the large header is a link back to the root. This results in confusing behaviour for those who use the middle mouse button to scroll, because attempting to scroll will open a new tab with the same page, and fail to scroll. This link is not very useful anyway since it leads to the page we are currently on. So it makes sense to just remove the link for the homepage.