### PR TITLE
Fix header overflow on mobile

### DIFF
--- a/assets/style.scss
+++ b/assets/style.scss
@@ -283,7 +283,6 @@ header {
       h2 {
         font-size: 18pt;
         padding-top: 9pt;
-        white-space: nowrap;
       }
     }
   }


### PR DESCRIPTION
This `white-space: nowrap` property is causing horizontal overflow on mobile right now:

![overflow](https://github.com/user-attachments/assets/f9ff42ca-b156-45fe-a72c-0435ad1307b1)